### PR TITLE
[currents] Fixes from the first day of alpha

### DIFF
--- a/.github/workflows/deploy_alpha.yml
+++ b/.github/workflows/deploy_alpha.yml
@@ -58,4 +58,4 @@ jobs:
             cd server &&
             dart pub get &&
             killall dart:main.dart ;
-            dart bin/main.dart >log 2>err &'
+            dart bin/main.dart >>log 2>>err &'

--- a/lib/util/async_throttle.dart
+++ b/lib/util/async_throttle.dart
@@ -8,7 +8,7 @@ class AsyncThrottle {
 
   bool _busy = false, _disposed = false;
   Object? _key, _nextKey;
-  List<Future<void> Function()>? _next;
+  Iterable<Future<void> Function()>? _next;
 
   void dispose() => _disposed = true;
 
@@ -26,7 +26,7 @@ class AsyncThrottle {
   /// functionality wouldn't work as well as operations can't be uncancelled, so
   /// sequences pre-empted by subsequent unique operations couldn't then be
   /// resumed if a later operation had the same key.
-  void schedule(List<Future<void> Function()> operations, {Object? key}) {
+  void schedule(Iterable<Future<void> Function()> operations, {Object? key}) {
     assert(!_disposed);
 
     if (key != null && _key == key) {

--- a/server/test/aquamarine_server_test.dart
+++ b/server/test/aquamarine_server_test.dart
@@ -171,6 +171,25 @@ void main() {
       verifyZeroInteractions(ofsClient);
     });
 
+    test('does not fetch when simulation would be too old', () async {
+      final ofsClient = MockOfsClient();
+      final persistence = FakePersistence();
+
+      final server = AquamarineServer(
+        ofsClient: ofsClient,
+        persistence: persistence,
+        clock: () => DateTime.utc(2023, 04, 01),
+      );
+
+      final past = HourUtc(1955, 11, 05, 12);
+
+      final response = await server.uv(past, past, bounds, .005).single;
+      expect(response.t, past);
+      expect(response.latLngHash, Hex32.zero);
+      expect(response.uv, emitsDone);
+      verifyZeroInteractions(ofsClient);
+    });
+
     test('attempts to fetch if a newer simulation might be available',
         () async {
       final ofsClient = MockOfsClient();


### PR DESCRIPTION
The first day of alpha saw one server crash, and it's clear that we want to avoid hammering things until we have better caching and robustness.

* Change deployment script to append to logs rather than overwrite.
* Remove prefetch for the graph time window.
* Do not try to download files from NOAA older than 31 days.