### PR TITLE
[server] Do not buffer streamed responses

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,8 +59,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build integration test apk
-        env:
-          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
         run: flutter build apk -t integration_test/integration_test.dart --debug -v
       - name: Upload integration test apk
         uses: actions/upload-artifact@v3
@@ -87,8 +85,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build native test apk
-        env:
-          MAPS_API_KEY: ${{ secrets.MAPS_API_KEY }}
         run: flutter build apk -t integration_test/native_test.dart --debug -v
       - name: Upload native test apk
         uses: actions/upload-artifact@v3

--- a/server/bin/main.dart
+++ b/server/bin/main.dart
@@ -83,7 +83,7 @@ Future<void> main() async {
                   unawaited(entry.close());
                 }
               }
-            }());
+            }(), context: const {'shelf.io.buffer_output': false});
           })),
     InternetAddress.anyIPv6,
     1080,

--- a/server/test/aquamarine_server_test.dart
+++ b/server/test/aquamarine_server_test.dart
@@ -219,8 +219,11 @@ void main() {
 
       // Make sure we can start receiving a new response even while the last one
       // is awaiting a write.
-      await verifyResponse(
-          await server.uv(sampleTime, sampleTime, bounds, .005).first);
+      final responses =
+          StreamIterator(server.uv(sampleTime, sampleTime, bounds, .005));
+      expect(await responses.moveNext(), true);
+      await verifyResponse(responses.current);
+      await responses.cancel();
     });
 
     test('updates response if a newer simulation is available', () async {


### PR DESCRIPTION
The server library was buffering streamed uv responses, starving the clients of cached data while refreshes were being fired.

The Flutter web client still buffers responses per dart-lang/http #593. A workaround may exist.