### PR TITLE
[server] Apply padding to initial fetch target, Tweak error logging

### DIFF
--- a/server/bin/main.dart
+++ b/server/bin/main.dart
@@ -16,22 +16,24 @@ import 'package:shelf_router/shelf_router.dart';
 
 void initializeLogger() {
   Logger.root.onRecord.listen((record) {
-    final Stdout out;
-    if (record.level >= Level.WARNING) {
-      out = stderr;
-    } else if (record.level >= Level.CONFIG) {
-      out = stdout;
-    } else {
-      return;
+    final message = '[${record.time.toUtc()}] ${record.level} '
+        '${record.loggerName}: ${record.message}';
+
+    if (record.level >= Level.WARNING ||
+        record.error != null ||
+        record.stackTrace != null) {
+      stderr.writeln(message);
     }
 
-    out.writeln('[${record.time.toUtc()}] ${record.level} '
-        '${record.loggerName}: ${record.message}');
+    if (record.level >= Level.CONFIG) {
+      stdout.writeln(message);
+    }
+
     if (record.error != null) {
-      out.writeln('\t${record.error}');
+      stderr.writeln('\t${record.error}');
     }
     if (record.stackTrace != null) {
-      out.writeln(record.stackTrace);
+      stderr.writeln(record.stackTrace);
     }
   });
 }

--- a/server/bin/main.dart
+++ b/server/bin/main.dart
@@ -142,7 +142,7 @@ Future<void> main() async {
     }
   }
 
-  HourUtc initial = HourUtc.truncate(DateTime.now().toUtc());
+  HourUtc initial = HourUtc.truncate(DateTime.now().toUtc().add(padding));
   // Align to last simulation run before now.
   initial -= (initial.hour - firstHour) % intervalHours;
 


### PR DESCRIPTION
commit b68047c69095b602aa06390d4f9adf1532fc0d02
Author: Ross Wang <imagipioneer@gmail.com>
Date:   Sat Jul 8 10:24:07 2023 -0700

    [server] Tweak error logging

    Echo some messages to both stderr and stdout.

commit 3417153e5aeb8646410cc774abbf830d26a8689a
Author: Ross Wang <imagipioneer@gmail.com>
Date:   Sat Jul 8 09:38:23 2023 -0700

    [server] Apply padding to initial fetch target

    The initial fetch timestamp calculation wasn't applying the padding, so restarting less than 45-ish minutes would make it try to download files that were not yet published.
