### PR TITLE
[server] Reduce persistence cache size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ This is a prototype cross-platform port of the BASK Trip Planner, for better off
 This project uses [Flutter](https://flutter.dev/). Install the dependencies as outlined at https://docs.flutter.dev/get-started/install, possibly stopping short of installing Flutter itself.
 
 Flutter needs a fork to address a couple issues:
-* https://github.com/flutter/flutter/issues/116212
-* <s>https://github.com/flutter/flutter/issues/82016</s> (still open but no longer required)
-* https://github.com/flutter/flutter/issues/119966
-* https://github.com/flutter/flutter/issues/102469
+* [flutter/flutter#116212](https://github.com/flutter/flutter/issues/116212)
+* <s>[flutter/flutter#82016](https://github.com/flutter/flutter/issues/82016)</s> (still open but no longer required)
+* [flutter/flutter#119966](https://github.com/flutter/flutter/issues/119966)
+* [flutter/flutter#102469](https://github.com/flutter/flutter/issues/102469)
 
 Fixes are at `git@github.com:AsturaPhoenix/flutter.git`, branch: `rosswang`. To use this fork,
 ```
-git clone git@github.com:AsturaPhoenix/flutter.git -b rosswang --depth 1
+git clone git@github.com:AsturaPhoenix/flutter.git -b rosswang
 ```
-(optionally omitting `--depth 1` if you anticipate working on the Flutter fork). Then proceed with the instructions at https://docs.flutter.dev/get-started/install after the analogous `git clone`.
+Then proceed with the instructions at https://docs.flutter.dev/get-started/install after the analogous `git clone`. Note a shallow clone will not work ([flutter/flutter#18532](https://github.com/flutter/flutter/issues/18532)).
 
 The project will probably build and run with a stock Flutter install, but there will be bugs, and integration tests won't work.
 
@@ -98,6 +98,11 @@ CI pushes a release build of the master branch to the alpha server at http://34.
 **Analysis failures in CI but not locally**
 
 * Try running `flutter pub upgrade` to pull the latest compatible versions of dependencies.
+
+**Flutter tools fail complaining of "v0.0.0-unknown"**
+
+* Shallow checkouts of Flutter will not work ([flutter/flutter#18532](https://github.com/flutter/flutter/issues/18532)).
+* Run `git fetch --unshallow` in your Flutter repo.
 
 ### Web
 

--- a/lib/widgets/compass.dart
+++ b/lib/widgets/compass.dart
@@ -339,7 +339,7 @@ class CompassState extends State<Compass>
                   final decomposition =
                       QuaternionDecomposition(animatedOrientation.data);
 
-                  // Planar deviation at which to enable the
+                  // Planar deviation at which to enable the camera.
                   const arThreshold = .5;
 
                   if (decomposition.planarDeviation > arThreshold) {
@@ -356,8 +356,8 @@ class CompassState extends State<Compass>
                       return Stack(
                         fit: StackFit.expand,
                         children: [
-                          // Don't show the camera UI at all if we know there's no
-                          //
+                          // Don't show the camera UI at all if we know there's
+                          // no camera.
                           if (camera.connectionState ==
                                   ConnectionState.waiting ||
                               cameraController != null)

--- a/server/bin/main.dart
+++ b/server/bin/main.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:aquamarine_server/aquamarine_server.dart';
 import 'package:aquamarine_server/ofs_client.dart';
+import 'package:aquamarine_server/persistence/caching.dart';
 import 'package:aquamarine_server/persistence/v2.dart';
 import 'package:aquamarine_server_interface/types.dart';
 import 'package:http/http.dart' as http;
@@ -47,7 +48,7 @@ Future<void> main() async {
 
   final instance = AquamarineServer(
     ofsClient: OfsClient(client: http.Client()),
-    persistence: await Persistence.load(),
+    persistence: CachingPersistence(await Persistence.load(), uvCacheSize: 64),
   );
   final server = await io.serve(
     Pipeline()

--- a/server/lib/aquamarine_server.dart
+++ b/server/lib/aquamarine_server.dart
@@ -9,7 +9,6 @@ import 'package:latlng/latlng.dart';
 import 'package:logging/logging.dart';
 
 import 'ofs_client.dart';
-import 'persistence/caching.dart';
 import 'persistence/persistence.dart';
 import 'types.dart';
 
@@ -58,9 +57,9 @@ class AquamarineServer {
 
   AquamarineServer({
     required this.ofsClient,
-    required Persistence persistence,
+    required this.persistence,
     this.clock = DateTime.now,
-  }) : persistence = CachingPersistence(persistence);
+  });
 
   final OfsClient ofsClient;
   final Persistence persistence;

--- a/server/test/aquamarine_server_test.dart
+++ b/server/test/aquamarine_server_test.dart
@@ -256,11 +256,11 @@ void main() {
       final responses =
           StreamIterator(server.uv(sampleTime, sampleTime, bounds, .005));
       expect(await responses.moveNext(), true);
-      verifyResponse(responses.current);
+      await verifyResponse(responses.current);
 
       controller.add(partialData[1]);
       expect(await responses.moveNext(), true);
-      verifyResponse(responses.current);
+      await verifyResponse(responses.current);
 
       expect(await responses.moveNext(), false);
       expect(persistence.allClosed, true);


### PR DESCRIPTION
commit 517a4e7d1fb9c2d6fdeaa17d6d5c9cf8780d7480
Author: Ross Wang <imagipioneer@gmail.com>
Date:   Thu Jul 13 10:47:20 2023 -0700

    [server] Reduce persistence cache size

    There may be a memory leak. As a first step, let's reduce the cache size.

    This change also decouples caching persistence the AquamarineServer constructor. AquamarineServer tests now run without cached persistence, which revealed a test bug where verification was not being awaited.

commit 7eeceb3cc42dc18173921e6a109ca185749b9f4b
Author: Ross Wang <imagipioneer@gmail.com>
Date:   Thu Jul 13 10:18:37 2023 -0700

    [camera] Fix a few comment deletions.

    A few comments were missing "camera."

commit f0ca8704cad4ab957bb941fc66512c6ba4ada11d
Author: Ross Wang <imagipioneer@gmail.com>
Date:   Thu Jul 13 10:01:27 2023 -0700

    [readme] Don't recommend shallow checkout of Flutter fork

    Shallow checkouts of Flutter don't work (flutter/flutter#18532).