### PR TITLE
[server] Fix padding in 19350eab17f99863d6e709e56b78ec4c6a62f16c

### DIFF
--- a/server/bin/main.dart
+++ b/server/bin/main.dart
@@ -145,7 +145,7 @@ Future<void> main() async {
     }
   }
 
-  HourUtc initial = HourUtc.truncate(DateTime.now().toUtc().add(padding));
+  HourUtc initial = HourUtc.truncate(DateTime.now().toUtc().subtract(padding));
   // Align to last simulation run before now.
   initial -= (initial.hour - firstHour) % intervalHours;
 


### PR DESCRIPTION
Applying padding to the initial fetch time needs to be via subtraction, not addition.