### PR TITLE
[server] Revert *.dill deployment

### DIFF
--- a/.github/workflows/deploy_alpha.yml
+++ b/.github/workflows/deploy_alpha.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Package web build
         run: cd build && tar --create -f web.tar.gz web
 
-      - run: cd server && dart pub get && dart compile kernel bin/main.dart
+      - run: dart compile kernel server/bin/main.dart
 
       - name: Set up SSH
         run: |

--- a/.github/workflows/deploy_alpha.yml
+++ b/.github/workflows/deploy_alpha.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Package web build
         run: cd build && tar --create -f web.tar.gz web
 
-      - run: dart compile kernel server/bin/main.dart
+      - name: Package server
+        run: tar --create -f server.tar.gz server util latlng
 
       - name: Set up SSH
         run: |
@@ -45,11 +46,14 @@ jobs:
             rm web.tar.gz'
 
       - name: Transfer server
-        run: 'scp server/bin/main.dill imagipioneer@${{ vars.ALPHA_IP }}:aquamarine_server'
-      - name: Migrate and flip
+        run: 'scp server.tar.gz imagipioneer@${{ vars.ALPHA_IP }}:aquamarine_server'
+      - name: Unpack and flip
         run: |
           ssh imagipioneer@${{ vars.ALPHA_IP }} '
             cd aquamarine_server &&
+            tar --overwrite -xvf server.tar.gz &&
+            rm server.tar.gz &&
+            cd server &&
+            dart pub get &&
             killall dart:main.dart ;
-            mv server/persistence persistence ;
-            dart main.dill >>log 2>>err &'
+            dart bin/main.dart >>log 2>>err &'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
       - run: cd server/ifc; dart test
       - run: cd server; dart test
       - run: flutter test
-      - uses: nanasess/setup-chromedriver@v1
+      - uses: nanasess/setup-chromedriver@v2
       - run: chromedriver --port=4444 &
       # -d chrome doesn't work with headless right now; https://github.com/flutter/flutter/issues/95085
       - run: flutter drive --driver=test_driver/integration_test.dart -t integration_test/integration_test.dart -d web-server


### PR DESCRIPTION
Dills are not portable across different Dart VM versions.