### PR TITLE
[server] Streamline BufferedReader

### DIFF
--- a/app/lib/providers/ofs_client.dart
+++ b/app/lib/providers/ofs_client.dart
@@ -143,13 +143,11 @@ class OfsClient extends ChangeNotifier {
           final samplePoints =
               await _samplePoints(_SamplingKey(hash, bounds, resolution));
 
-          await readVectors(
-            reader,
-            () => !isCancelled() && entry.uv.length < samplePoints.length,
-            entry.uv.add,
-          );
-
-          if (isCancelled()) return;
+          final vectorData = reader.substream(8 * samplePoints.length);
+          await for (final vectors in readVectors(BufferedReader(vectorData))) {
+            if (isCancelled()) return;
+            vectors.forEach(entry.uv.add);
+          }
 
           if (samplePoints.length != entry.uv.length) {
             throw FormatException('Unexpected end of stream; received '

--- a/server/ifc/lib/src/buffered_reader.dart
+++ b/server/ifc/lib/src/buffered_reader.dart
@@ -3,8 +3,8 @@ import 'dart:math';
 import 'dart:typed_data';
 
 /// This is functionally similar to
-/// [package:async/async.dart ChunkedStreamReader] but aims to be more
-/// efficient.
+/// [package:async/async.dart ChunkedStreamReader] but is more efficient,
+/// particularly with larger chunk sizes.
 class BufferedReader {
   BufferedReader(Stream<List<int>> stream) : iterator = StreamIterator(stream);
 
@@ -49,6 +49,54 @@ class BufferedReader {
     final data = buffer.takeBytes();
     buffer.add(Uint8List.sublistView(data, size));
     return Uint8List.sublistView(data, 0, size);
+  }
+
+  /// Converts the reader into a stream that produces chunks that are multiples
+  /// of [size]. This operation consumes the reader.
+  Stream<Uint8List> withAlignment(int size) async* {
+    try {
+      while (buffer.isNotEmpty || await moveNext()) {
+        // This covers the 0-length chunk case.
+        if (buffer.isEmpty) continue;
+
+        while (buffer.length < size) {
+          await requireNext();
+        }
+
+        final bytes = buffer.takeBytes();
+        final end = bytes.length - bytes.length % size;
+        yield Uint8List.sublistView(bytes, 0, end);
+        buffer.add(bytes.sublist(end));
+      }
+    } finally {
+      await cancel();
+    }
+  }
+
+  /// Similar to [package:async/async.dart ChunkedStreamReader.readStream], but
+  /// does not drain on cancellation, and throws a [FormatException] if the
+  /// stream ends before [size] is read.
+  Stream<Uint8List> substream(int size) async* {
+    int bytesRead = 0;
+    while (buffer.isNotEmpty || await moveNext()) {
+      if (bytesRead + buffer.length < size) {
+        bytesRead += buffer.length;
+        yield buffer.takeBytes();
+      } else {
+        final bytesWanted = size - bytesRead;
+        final bytes = buffer.takeBytes();
+        if (bytes.length < 2 * bytesWanted) {
+          yield Uint8List.sublistView(bytes, 0, bytesWanted);
+          buffer.add(bytes.sublist(bytesWanted));
+        } else {
+          yield bytes.sublist(0, bytesWanted);
+          buffer.add(Uint8List.sublistView(bytes, bytesWanted));
+        }
+        return;
+      }
+    }
+
+    throw FormatException('Unexpected end of stream.');
   }
 
   Future<void> consumeUntil(Uint8List marker) async {

--- a/server/test/aquamarine_server_test.dart
+++ b/server/test/aquamarine_server_test.dart
@@ -48,14 +48,11 @@ void main() {
         expect(response.latLngHash, kLatlngHash);
 
         int vectorCount = 0;
-        final reader = BufferedReader(response.uv);
-        try {
-          await readVectors(reader, () => true, (vector) {
+        await for (final vectors in readVectors(BufferedReader(response.uv))) {
+          for (final vector in vectors) {
             expect(vector.length, lessThan(kSpeedLimit));
             ++vectorCount;
-          });
-        } finally {
-          reader.cancel();
+          }
         }
 
         expect(vectorCount, inInclusiveRange(100, 1000));

--- a/server/test/ofs_client_test.dart
+++ b/server/test/ofs_client_test.dart
@@ -95,17 +95,11 @@ void main() {
       );
 
       int count = 0;
-      final reader = BufferedReader(result);
-      try {
-        await readLatLngs(reader, (latlng) {
-          expect(
-            latlng,
-            predicate((LatLng latlng) => bounds.contains(latlng)),
-          );
+      await for (final latlngs in readLatLngs(BufferedReader(result))) {
+        for (final latlng in latlngs) {
+          expect(latlng, predicate((LatLng latlng) => bounds.contains(latlng)));
           ++count;
-        });
-      } finally {
-        reader.cancel();
+        }
       }
 
       expect(count, kOfsNele);
@@ -116,14 +110,11 @@ void main() {
       expect(result.latlngHash, kLatlngHash);
 
       int count = 0;
-      final reader = BufferedReader(result.uv);
-      try {
-        await readVectors(reader, () => true, (vector) {
+      await for (final vectors in readVectors(BufferedReader(result.uv))) {
+        for (final vector in vectors) {
           expect(vector.length, lessThan(kSpeedLimit));
           ++count;
-        });
-      } finally {
-        reader.cancel();
+        }
       }
 
       expect(count, kOfsNele);


### PR DESCRIPTION
`BufferedReader` was pretty hard to use correctly. Tried to migrate to [`ChunkedStreamReader`](https://api.flutter.dev/flutter/async/ChunkedStreamReader-class.html) in the hopes that `BufferedReader` was premature optimization, but the performance hit was substantial. Refactored `BufferedReader` to be similar to `ChunkedStreamReader` where possible without sacrificing too much performance.