### PR TITLE
[server] Fix server considering ClientExceptions as successes

### DIFF
--- a/server/bin/main.dart
+++ b/server/bin/main.dart
@@ -18,7 +18,16 @@ import 'package:shelf_router/shelf_router.dart';
 
 void initializeLogger() {
   Logger.root.onRecord.listen((record) {
-    final message = '[${record.time.toUtc()}] ${record.level} '
+    // The default stringization is at microsecond resolution but omits the
+    // microsegment fragment if the microseconds part is 0. Both the
+    // inconsistency and the microseconds themselves are not ideal in the logs,
+    // so let's truncate them.
+    final formattedTime = DateTime.fromMillisecondsSinceEpoch(
+      record.time.millisecondsSinceEpoch,
+      isUtc: true,
+    ).toString();
+
+    final message = '[$formattedTime] ${record.level} '
         '${record.loggerName}: ${record.message}';
 
     if (record.level >= Level.WARNING ||

--- a/server/lib/aquamarine_server.dart
+++ b/server/lib/aquamarine_server.dart
@@ -299,6 +299,7 @@ class AquamarineServer {
             final uv = await ofsClient.fetchUv(simulationTime);
             await persistence.writeUv(simulationTime, latlngHash!, uv);
           }
+          return FetchResult.success;
         } on ResourceException catch (e) {
           log.warning(e.message);
 
@@ -312,8 +313,8 @@ class AquamarineServer {
           }
         } on http.ClientException catch (e, s) {
           log.warning('Failed to fetch $simulationTime', e, s);
+          return FetchResult.transientFailure;
         }
-        return FetchResult.success;
       });
 
       switch (result) {


### PR DESCRIPTION
Miscategorized `ClientException`s as successes. Moved the success return statement to prevent such cases in the future. Added a test dedicated to the `ClientException` failure mode (test existed for 500s).